### PR TITLE
core: add support for custom log function

### DIFF
--- a/src/core/dprint.c
+++ b/src/core/dprint.c
@@ -46,6 +46,7 @@ static void log_callid_set(sip_msg_t *msg);
 
 char *_km_log_engine_type = NULL;
 char *_km_log_engine_data = NULL;
+km_custom_log_f _km_custom_log_func = &km_default_custom_log_func;
 
 km_log_f _km_log_func = &syslog;
 
@@ -55,6 +56,24 @@ km_log_f _km_log_func = &syslog;
 void km_log_func_set(km_log_f f)
 {
 	_km_log_func = f;
+}
+
+void km_custom_log_func_set(km_custom_log_f f)
+{
+	_km_custom_log_func = f;
+}
+
+// default custom log format handler,
+// expected to be replaced via km_custom_log_func_set
+void km_default_custom_log_func(int syslog_level, const char *mod_name, const char *file_name,
+							    int line, const char *fmt, ...)
+{
+	char *custom_fmt;
+	asprintf(&custom_fmt, "%s %i:%s:%i %s", mod_name, my_pid(), file_name, line, fmt);
+	va_list args;
+    va_start (args, fmt);
+    vsyslog(syslog_level, custom_fmt, args);
+    va_end (args);
 }
 
 #ifndef NO_SIG_DEBUG


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Allow Kamailio modules to register their log function so that all Kamailio log messages (coming from core and other modules) are logged uniformly in the format defined by the custom log function. 

In order to enable the custom log format feature, Kamailio must be compiled with the `CUSTOM_LOG_FMT` flag. Then the module that wishes to modify the log format has to call `km_custom_log_func_set` during the initialisation to supply a custom log formatting function (see `km_default_custom_log_func` as an example).
