### PR TITLE
core: add custom function to check emergency URN

### DIFF
--- a/src/core/parser/parse_uri.c
+++ b/src/core/parser/parse_uri.c
@@ -237,28 +237,30 @@ int parse_uri(char *buf, int len, struct sip_uri *uri)
 	} else                                                 \
 		goto error_bad_char
 
-#define check_host_end         \
-	case ':':                  \
-		/* found the host */   \
-		uri->host.s = s;       \
-		uri->host.len = p - s; \
-		state = URI_PORT;      \
-		s = p + 1;             \
-		break;                 \
-	case ';':                  \
-		uri->host.s = s;       \
-		uri->host.len = p - s; \
-		state = URI_PARAM;     \
-		s = p + 1;             \
-		break;                 \
-	case '?':                  \
-		uri->host.s = s;       \
-		uri->host.len = p - s; \
-		state = URI_HEADERS;   \
-		s = p + 1;             \
-		break;                 \
-	case '&':                  \
-	case '@':                  \
+#define check_host_end             \
+	case ':':                      \
+		/* found the host */       \
+		if(scheme != URN_SCH) {    \
+			uri->host.s = s;       \
+			uri->host.len = p - s; \
+			state = URI_PORT;      \
+			s = p + 1;             \
+		}                          \
+		break;                     \
+	case ';':                      \
+		uri->host.s = s;           \
+		uri->host.len = p - s;     \
+		state = URI_PARAM;         \
+		s = p + 1;                 \
+		break;                     \
+	case '?':                      \
+		uri->host.s = s;           \
+		uri->host.len = p - s;     \
+		state = URI_HEADERS;       \
+		s = p + 1;                 \
+		break;                     \
+	case '&':                      \
+	case '@':                      \
 		goto error_bad_char
 
 
@@ -493,7 +495,7 @@ int parse_uri(char *buf, int len, struct sip_uri *uri)
 					case '@': /* error no user part, or
 								* be forgiving and accept it ? */
 					default:
-						state = URI_USER;
+						state = (scheme == URN_SCH) ? URI_HOST : URI_USER;
 				}
 				break;
 			case URI_USER:


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Improved URN parsing according to [RFC8141](https://datatracker.ietf.org/doc/html/rfc8141#section-2) that allows an arbitrary number of colons to be present in the URN value. Entire URN NID and NSS parts (except for `urn:` scheme) are stored in the `uri.host` struct field. `rq-components` are not supported.

Example of the parse error when parsing "urn:emergency:service:sos"
```
parse_uri(): bad char ':' in state 3 parsed: urn:emergency:service (21) / urn:emergency:service:sos (25)
```

URN values that have been tested to work:
- `urn:emergency:service:sos`
- `urn:emergency:responder.fire`
- `urn:emergency:media-feature`